### PR TITLE
delete : TagsInput태그 안 필요없는 코드 삭제

### DIFF
--- a/client/src/components/Diary/DiaryEditor.js
+++ b/client/src/components/Diary/DiaryEditor.js
@@ -138,9 +138,9 @@ function DiaryEditor({
 
   /*<------------------------------ 수정중인 함수 (태그 클릭시 해당 해시태그의 글 리스트 모아서 보여주기) --------------------------------->*/
 
-  // function handleHashtags() {
-  //   console.log(localHashtags);
-  // }
+  function handleHashtags() {
+    console.log(localHashtags);
+  }
 
   /*<--------------------------------------------------------------------------------------------------------------------->*/
 
@@ -194,22 +194,7 @@ function DiaryEditor({
             <div className="content">{content}</div>
             <div className="hashtags">
               {localHashtags.length === 0 ? (
-                <TagsInput display="none">
-                  <ul id="tags">
-                    {localHashtags.map((tag, index) => (
-                      <li key={index} className="tag">
-                        <span
-                          className="tag-title"
-                          onClick={() => {
-                            console.log(localHashtags);
-                          }}
-                        >
-                          {tag}
-                        </span>
-                      </li>
-                    ))}
-                  </ul>
-                </TagsInput>
+                <TagsInput display="none" />
               ) : (
                 <TagsInput display="flex">
                   <ul id="tags">
@@ -218,7 +203,7 @@ function DiaryEditor({
                         <span
                           className="tag-title"
                           onClick={() => {
-                            console.log(localHashtags);
+                            handleHashtags();
                           }}
                         >
                           {tag}


### PR DESCRIPTION
1.  DiaryEdit.js안의 `TagsInput` 컴포넌트 코드 중 불필요한 요소 삭제